### PR TITLE
Updated Alert.js with docs on options parameter

### DIFF
--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -72,7 +72,17 @@ type Options = {
  * ```
  */
 class Alert {
-
+  
+  /**
+   * Displays an alert dialog
+   *
+   * Options is an object that accepts `cancelable`. If true,
+   * the modal will not close by pressing the background, only
+   * by pressing a button.
+   *
+   * Example:
+   * `{cancelable: true}`
+   */
   static alert(
     title: ?string,
     message?: ?string,


### PR DESCRIPTION
While reading the docs on the [Alert API](https://facebook.github.io/react-native/docs/alert.html), I could not find any documentation for the options parameter, and after a few minutes of searching I found it towards the bottom and looking at the code.

I added the options `cancelable` documentation to the method documentation.
